### PR TITLE
Fix Julia 1.0 compatibility

### DIFF
--- a/src/dither_api.jl
+++ b/src/dither_api.jl
@@ -48,7 +48,7 @@ end
 
 # Default return type for grayscale algs: type of color scheme `cs`
 function dither(
-    img::GenericImage, alg::AbstractDither, cs::AbstractVector{T}, args...; kwargs...
+    img::GenericImage, alg::AbstractColorDither, cs::AbstractVector{T}, args...; kwargs...
 ) where {T<:Colorant}
     return dither(T, img, alg, cs, args...; kwargs...)
 end


### PR DESCRIPTION
Previously got `LoadError: cannot add methods to an abstract type` on Julia 1.0 because of the following line:
https://github.com/JuliaImages/DitherPunk.jl/blob/b342bf92f556a17ed2a18959af5ddf99d8fe0113/src/ordered.jl#L12-L14

## Changes
Fixed by turning `AbstractOrderedDither` into a concrete type `OrderedDither`. This simplifies the code and matches the implementation in `src/error_diffusion.jl`.

**Potential downside:**
Functions such as `Bayer` now return a `OrderedDither` struct instead of a matching `Bayer` struct. 