### PR TITLE
Add references to docstrings

### DIFF
--- a/src/ordered.jl
+++ b/src/ordered.jl
@@ -45,6 +45,10 @@ end
 Ordered dithering using the Bayer matrix as a threshold matrix.
 The Bayer matrix is of dimension ``2^{n+1} \\times 2^{n+1}``, where ``n`` is the `level`,
 which defaults to `1`.
+
+[1]  Bayer, B.E., "An Optimum Method for Two-Level Rendition of Continuous
+     Tone Pictures," IEEE International Conference on Communications,
+     Conference Records, 1973, pp. 26-11 to 26-15.
 """
 function Bayer(; level=1)
     bayer = bayer_matrix(level)


### PR DESCRIPTION
Closes #19.

Also internally renames `stencil` to `filter`, as the literature typically refers to "error filters".