### PR TITLE
Separate binary and color algorithm implementations

### DIFF
--- a/src/closest_color.jl
+++ b/src/closest_color.jl
@@ -5,18 +5,16 @@ Technically this not a dithering algorithm as the quatization error is not "rand
 """
 struct ClosestColor <: AbstractCustomColorDither end
 
-function (alg::ClosestColor)(
+function binarydither!(::ClosestColor, out::GenericGrayImage, img::GenericGrayImage)
+    return out .= img .> 0.5
+end
+
+function colordither!(
+    ::ClosestColor,
     out::GenericImage,
     img::GenericImage,
     cs::AbstractVector{<:Pixel},
     metric::DifferenceMetric,
 )
     return out .= eltype(out).(map((px) -> closest_color(px, cs; metric=metric), img))
-end
-
-# default to binary dithering if no color scheme is provided
-function (alg::ClosestColor)(out::GenericGrayImage, img::GenericGrayImage)
-    cs = eltype(out).([false, true]) # b&w color scheme
-    alg(out, img, cs, BinaryDitherMetric())
-    return out
 end

--- a/src/colorspaces.jl
+++ b/src/colorspaces.jl
@@ -1,34 +1,28 @@
 """
-Convert from sRGB to linear color space.
+    srgb2linear(u)
+
+Convert pixel `u` from sRGB to linear color space.
 """
 @inline srgb2linear(u::Number) = Colors.invert_srgb_compand(u)
 @inline srgb2linear(u::Gray) = typeof(u)(srgb2linear(gray(u)))
 @inline srgb2linear(u::Bool) = u
 
 """
-Convert from linear to sRGB color space.
+    linear2srgb(u)
+
+Convert pixel `u` from linear to sRGB color space.
 """
 @inline linear2srgb(u::Number) = Colors.srgb_compand(u)
 @inline linear2srgb(u::Gray) = typeof(u)(linear2srgb(gray(u)))
 @inline linear2srgb(u::Bool) = u
 
 """
+    closest_color(color, cs; metric=DE_2000())
+
 Return color in ColorScheme `cs` that is closest to `color`
 [according to `colordiff`](http://juliagraphics.github.io/Colors.jl/dev/colordifferences/#Color-Differences)
 """
 function closest_color(color::Color, cs::AbstractVector{<:Color}; metric=DE_2000())
     imin = argmin(colordiff.(color, cs; metric=metric))
     return cs[imin]
-end
-function closest_color(color::Real, cs::AbstractVector{<:Real}; kwargs...)
-    return closest_color(Gray(color), Gray.(cs); kwargs...)
-end
-
-"""
-Define custom color difference metric with linear distances between grayscale values.
-"""
-struct BinaryDitherMetric <: DifferenceMetric end
-
-function ImageCore.Colors._colordiff(a::Gray, b::Gray, m::BinaryDitherMetric)
-    return abs(a - b)
 end

--- a/src/error_diffusion.jl
+++ b/src/error_diffusion.jl
@@ -45,8 +45,8 @@ function binarydither!(alg::ErrorDiffusion, out::GenericGrayImage, img::GenericG
     dcs = axes(alg.filter, 2)
     FT0, FT1 = FT(0), FT(1)
 
-    @inbounds for r in 1:h
-        for c in 1:w
+    @inbounds for r in axes(img, 1)
+        for c in axes(img, 2)
             px = img[r, c]
             alg.clamp_error && (px = clamp01(px))
 
@@ -56,7 +56,7 @@ function binarydither!(alg::ErrorDiffusion, out::GenericGrayImage, img::GenericG
 
             for dr in drs
                 for dc in dcs
-                    if (r + dr > 0) && (r + dr <= h) && (c + dc > 0) && (c + dc <= w)
+                    if (r + dr) in axes(img, 1) && (c + dc) in axes(img, 2)
                         img[r + dr, c + dc] += err * filter[dr, dc]
                     end
                 end
@@ -91,8 +91,8 @@ function colordither!(
     drs = axes(alg.filter, 1)
     dcs = axes(alg.filter, 2)
 
-    @inbounds for r in 1:h
-        for c in 1:w
+    @inbounds for r in axes(img, 1)
+        for c in axes(img, 2)
             px = img[r, c]
             alg.clamp_error && (px = clamp01(px))
 
@@ -102,7 +102,7 @@ function colordither!(
 
             for dr in drs
                 for dc in dcs
-                    if (r + dr > 0) && (r + dr <= h) && (c + dc > 0) && (c + dc <= w)
+                    if (r + dr) in axes(img, 1) && (c + dc) in axes(img, 2)
                         img[r + dr, c + dc] += err * filter[dr, dc]
                     end
                 end

--- a/src/error_diffusion.jl
+++ b/src/error_diffusion.jl
@@ -27,8 +27,48 @@ struct ErrorDiffusion{T<:AbstractMatrix} <: AbstractCustomColorDither
 end
 ErrorDiffusion(filter; clamp_error=true) = ErrorDiffusion(filter, clamp_error)
 
-# Error diffusion for general color schemes `cs`.
-function (alg::ErrorDiffusion)(
+function binarydither!(alg::ErrorDiffusion, out::GenericGrayImage, img::GenericGrayImage)
+    # this function does not yet support OffsetArray
+    require_one_based_indexing(img)
+
+    # Change from normalized intensities to Float as error will get added!
+    FT = floattype(eltype(out))
+
+    # eagerly promote to the same type to make loop run faster
+    img = FT.(img)
+    filter = eltype(FT).(alg.filter)
+
+    h, w = size(img)
+    fill!(out, zero(eltype(out)))
+
+    drs = axes(alg.filter, 1)
+    dcs = axes(alg.filter, 2)
+    FT0, FT1 = FT(0), FT(1)
+
+    @inbounds for r in 1:h
+        for c in 1:w
+            px = img[r, c]
+            alg.clamp_error && (px = clamp01(px))
+
+            px >= 0.5 ? (col = FT1) : (col = FT0) # round to closest color
+            out[r, c] = col # apply pixel to dither
+            err = px - col  # diffuse "error" to neighborhood in filter
+
+            for dr in drs
+                for dc in dcs
+                    if (r + dr > 0) && (r + dr <= h) && (c + dc > 0) && (c + dc <= w)
+                        img[r + dr, c + dc] += err * filter[dr, dc]
+                    end
+                end
+            end
+        end
+    end
+
+    return out
+end
+
+function colordither!(
+    alg::ErrorDiffusion,
     out::GenericImage,
     img::GenericImage,
     cs::AbstractVector{<:Pixel},
@@ -56,14 +96,9 @@ function (alg::ErrorDiffusion)(
             px = img[r, c]
             alg.clamp_error && (px = clamp01(px))
 
-            # Round to closest color
-            col = closest_color(px, cs; metric=metric)
-
-            # Apply pixel to dither
-            out[r, c] = col
-
-            # Diffuse "error" to neighborhood in filter
-            err = px - col
+            col = closest_color(px, cs; metric=metric) # round to closest color
+            out[r, c] = col # apply pixel to dither
+            err = px - col  # diffuse "error" to neighborhood in filter
 
             for dr in drs
                 for dc in dcs
@@ -75,13 +110,6 @@ function (alg::ErrorDiffusion)(
         end
     end
 
-    return out
-end
-
-# default to binary dithering if no color scheme is provided
-function (alg::ErrorDiffusion)(out::GenericGrayImage, img::GenericGrayImage)
-    cs = eltype(out).([false, true]) # b&w color scheme
-    alg(out, img, cs, BinaryDitherMetric())
     return out
 end
 

--- a/src/ordered.jl
+++ b/src/ordered.jl
@@ -12,8 +12,8 @@ struct OrderedDither{T<:AbstractMatrix} <: AbstractBinaryDither
     mat::T
 end
 
-function (alg::OrderedDither)(
-    out::GenericGrayImage, img::GenericGrayImage; invert_map=false
+function binarydither!(
+    alg::OrderedDither, out::GenericGrayImage, img::GenericGrayImage; invert_map=false
 )
     # eagerly promote to the same eltype to make for-loop faster
     FT = floattype(eltype(img))

--- a/src/threshold.jl
+++ b/src/threshold.jl
@@ -7,7 +7,7 @@ Use white noise as a threshold map.
 """
 struct WhiteNoiseThreshold <: AbstractThresholdDither end
 
-function (alg::WhiteNoiseThreshold)(out::GenericGrayImage, img::GenericGrayImage)
+function binarydither!(::WhiteNoiseThreshold, out::GenericGrayImage, img::GenericGrayImage)
     tmap = rand(eltype(img), size(img))
     out .= img .> tmap
     return out
@@ -29,7 +29,7 @@ struct ConstantThreshold{T<:Real} <: AbstractThresholdDither
     end
 end
 
-function (alg::ConstantThreshold)(out::GenericGrayImage, img::GenericGrayImage)
+function binarydither!(alg::ConstantThreshold, out::GenericGrayImage, img::GenericGrayImage)
     tmap = fill(alg.threshold, size(img)) # constant matrix of value threshold
     out .= img .> tmap
     return out

--- a/test/test_color.jl
+++ b/test/test_color.jl
@@ -1,5 +1,5 @@
 using DitherPunk
-using DitherPunk: closest_color
+using DitherPunk: closest_color, ColorNotImplementedError
 using Images
 using ImageCore
 using ImageInTerminal
@@ -54,10 +54,8 @@ for (name, alg) in algs
 end
 
 # Test for argument errors on AbstractBinaryDither algorithms
-if VERSION >= v"1.5"
-    for alg in [Bayer(), WhiteNoiseThreshold(), ConstantThreshold()]
-        @test_throws ArgumentError dither(img, alg, cs)
-    end
+for alg in [Bayer(), WhiteNoiseThreshold(), ConstantThreshold()]
+    @test_throws ColorNotImplementedError dither(img, alg, cs)
 end
 
 # Test conditional dependency on ColorSchemes.jl


### PR DESCRIPTION
Currently `ErrorDiffusion` and `ClosestColor` algorithms use generalized algorithms that work on any color palette.
We can speed things up by splitting the internal implementation into `binarydither!` and `colordither!`. This comes at the small cost of some code duplication. 