### PR TITLE
fix docstring dispatch

### DIFF
--- a/src/clustering.jl
+++ b/src/clustering.jl
@@ -31,7 +31,7 @@ Dither image `img` using algorithm `alg`.
 A color palette with `ncolors` is computed by Clustering.jl's K-means clustering.
 The amount of `maxiter` and tolerance `tol` default to those exported by Clustering.jl.
 """
-dither!
+dither!(img, alg::AbstractDither, ncolors::Int; kwargs...)
 
 """
     dither([T::Type,] img, alg::AbstractDither, ncolors; maxiter, tol, kwargs...)
@@ -40,4 +40,4 @@ Dither image `img` using algorithm `alg`.
 A color palette with `ncolors` is computed by Clustering.jl's K-means clustering.
 The amount of `maxiter` and tolerance `tol` default to those exported by Clustering.jl.
 """
-dither
+dither(::Type, img, alg::AbstractDither, ncolors::Int; kwargs...)


### PR DESCRIPTION
This fixes the following warning:

```julia
julia> using DitherPunk

julia> using Clustering
┌ Warning: Replacing docs for `DitherPunk.dither! :: Union{}` in module `DitherPunk`
└ @ Base.Docs docs/Docs.jl:240
┌ Warning: Replacing docs for `DitherPunk.dither :: Union{}` in module `DitherPunk`
└ @ Base.Docs docs/Docs.jl:240

help?> dither
search: dither dither! DitherPunk OrderedDither isdispatchtuple

  dither([T::Type,] img, alg::AbstractDither, ncolors; maxiter, tol, kwargs...)


  Dither image img using algorithm alg. A color palette with ncolors is computed by Clustering.jl's K-means clustering. The amount of
  maxiter and tolerance tol default to those exported by Clustering.jl.
```

After: two pieces of method docstring

```julia
julia> using DitherPunk

julia> using Clustering

help?> dither
search: dither dither! DitherPunk OrderedDither isdispatchtuple

  dither([T::Type,] img, alg::AbstractDither, args...; kwargs...)


  Dither image img using algorithm alg.

  Output
  ≡≡≡≡≡≡≡≡

  If no return type is specified, dither will default to the type of the input image.

  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  dither([T::Type,] img, alg::AbstractDither, ncolors; maxiter, tol, kwargs...)


  Dither image img using algorithm alg. A color palette with ncolors is computed by Clustering.jl's K-means clustering. The amount of
  maxiter and tolerance tol default to those exported by Clustering.jl.
```