### PR TITLE
Add ASCII ramp example to docs

### DIFF
--- a/docs/literate/ascii.jl
+++ b/docs/literate/ascii.jl
@@ -1,0 +1,26 @@
+# # ASCII dithering
+# In this example, we are going to approximate a grayscale gradient
+# with an ASCII ramp such as ` .:-=+*#%@`.
+using Images
+using DitherPunk
+using TestImages
+
+# When loading an image, we need to compensate for the aspect ratio of ASCII characters.
+img = testimage("cameraman")
+img = imresize(img, ratio=(1//14, 1//6))
+
+# We then define an ASCII ramp and a corresponding grayscale color scheme of matching length.
+ascii_ramp = split(" .:-=+*#%@", "")
+cs = Gray.(range(0, 1, length=10))
+
+# Dithering will return an `IndirectArray`:
+d = dither(img, FloydSteinberg(), cs)
+
+# Instead of showing `d` as an image, we can use its indices
+# to select the corresponding ASCII characters from the ramp.
+mat = ascii_ramp[d.index]
+
+# Pretty printing each row of this matrix will output the image:
+for r in eachrow(mat)
+    println(join(r))
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(;
             "Images" => "generated/gallery_images.md",
         ],
         "Fun applications" => Any[
+            "ASCII dithering" => "generated/ascii.md",
             "SDF halftoning" => "generated/sdf_halftoning.md",
             "Color cycling" => "generated/color_cycling.md",
             "Palette swapping" => "generated/palette_swapping.md",


### PR DESCRIPTION
Adds the example shown in #61.