### PR TITLE
Fix stable doc build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,13 @@
 name: CI
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
+    tags: '*'
+  pull_request:
+    branches:
+      - master
+      
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
Stable docs haven't been building since `v2.0.0`, when I mistakenly removed `tags: ‘*’` in CI.yml. 