### PR TITLE
downsample the image before clustering

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,16 @@ authors = ["Adrian Hill"]
 version = "2.3.1"
 
 [deps]
-ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageBase = "c817782e-172a-44cc-b673-b171935fbb9e"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
+ImageBase = "0.1.3"
 Clustering = "0.14"
 ColorSchemes = "3"
-ImageCore = "0.8.1, 0.9"
 IndirectArrays = "0.5, 1.0"
 OffsetArrays = "1"
 Requires = "1"

--- a/src/DitherPunk.jl
+++ b/src/DitherPunk.jl
@@ -1,8 +1,8 @@
 module DitherPunk
 
-using ImageCore
-using ImageCore: NumberLike, Pixel, GenericImage, GenericGrayImage, MappedArrays
-using ImageCore.Colors: DifferenceMetric
+using ImageBase
+using ImageBase.ImageCore: NumberLike, Pixel, GenericImage, GenericGrayImage, MappedArrays
+using ImageBase.ImageCore.Colors: DifferenceMetric
 using Random
 using IndirectArrays
 using OffsetArrays

--- a/src/clustering.jl
+++ b/src/clustering.jl
@@ -7,11 +7,24 @@ function get_colorscheme(
     tol=Clustering._kmeans_default_tol,
 )::Vector{Lab}
     # Cluster in Lab color space
-    data = reshape(channelview(Lab.(img)), 3, :)
+
+    # Clustering on the downsampled image already generates good enough colormap estimation
+    # This significantly reduces the algorithmic complexity.
+    img = _restrict_to(img, ncolors*100)
+    data = convert(Array{Float32}, reshape(channelview(Lab.(img)), 3, :))
     R = Clustering.kmeans(data, ncolors; maxiter=maxiter, tol=tol)
 
     # Make color scheme out of cluster centers
     return [Lab(c...) for c in eachcol(R.centers)]
+end
+
+function _restrict_to(img, n)
+    length(img) <= n && return img
+    out = restrict(img)
+    while length(out) > n
+        out = restrict(out)
+    end
+    return out
 end
 
 function _colordither(

--- a/src/clustering.jl
+++ b/src/clustering.jl
@@ -11,7 +11,7 @@ function get_colorscheme(
     # Clustering on the downsampled image already generates good enough colormap estimation
     # This significantly reduces the algorithmic complexity.
     img = _restrict_to(img, ncolors*100)
-    data = convert(Array{Float32}, reshape(channelview(Lab.(img)), 3, :))
+    data = reshape(channelview(Lab.(img)), 3, :)
     R = Clustering.kmeans(data, ncolors; maxiter=maxiter, tol=tol)
 
     # Make color scheme out of cluster centers

--- a/test/test_color.jl
+++ b/test/test_color.jl
@@ -1,7 +1,7 @@
 using DitherPunk
 using DitherPunk: ColorNotImplementedError
 using IndirectArrays
-using ImageCore
+using ImageBase
 using ReferenceTests
 using TestImages
 

--- a/test/test_fixed_color.jl
+++ b/test/test_fixed_color.jl
@@ -1,5 +1,5 @@
 using DitherPunk
-using ImageCore
+using ImageBase
 using ReferenceTests
 using TestImages
 

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -2,8 +2,8 @@ using DitherPunk
 using DitherPunk: gradient_image
 using ReferenceTests
 
-using ImageCore
-using ImageCore: GenericGrayImage
+using ImageBase
+using ImageBase.ImageCore: GenericGrayImage
 using UnicodePlots
 
 w = 200

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,6 +1,6 @@
 using DitherPunk
 using DitherPunk: srgb2linear, clamp_limits
-using ImageCore
+using ImageBase
 
 @test srgb2linear(true) == true
 @test srgb2linear(false) == false


### PR DESCRIPTION
For any real-world image, clustering the image pixel is a computational intensive big-data problem. For our very purpose to estimate the colormap, a downsampled
the version already works well.

```julia
using DitherPunk, TestImages, Clustering

img_gray = testimage("cameraman")
img_color = testimage("lighthouse")

@time dither(img_gray, FloydSteinberg(), 8)
# PR: 0.477710 seconds (30.36 M allocations: 559.455 MiB, 9.76% gc time)
# master: 0.693541 seconds (31.94 M allocations: 610.524 MiB, 7.57% gc time)

@time dither(img_color, FloydSteinberg(), 24)
# PR: 2.002484 seconds (120.32 M allocations: 1.937 GiB, 7.40% gc time)
# master: 8.085305 seconds (124.17 M allocations: 2.187 GiB, 2.26% gc time, 0.32% compilation time)
```

The results are not identical but the visual quality looks quite similar. I think this is a good improvement overall (not a breaking change).