### PR TITLE
Add default method for `braille` and option to invert output

### DIFF
--- a/src/api/default_method.jl
+++ b/src/api/default_method.jl
@@ -1,5 +1,6 @@
 const DEFAULT_METHOD = FloydSteinberg()
 
+# Binary and per-channel dithering
 function dither!(out::GenericImage, img::GenericImage; kwargs...)
     return dither!(out, img, DEFAULT_METHOD; kwargs...)
 end
@@ -13,6 +14,7 @@ function dither(img::GenericImage; kwargs...)
     return dither(img, DEFAULT_METHOD; kwargs...)
 end
 
+# Dithering with custom colors
 for T in (AbstractVector{<:Colorant}, ColorScheme, Integer)
     @eval function dither!(out::GenericImage, img::GenericImage, arg::$T; kwargs...)
         return dither!(out, img, DEFAULT_METHOD, arg; kwargs...)
@@ -26,4 +28,9 @@ for T in (AbstractVector{<:Colorant}, ColorScheme, Integer)
     @eval function dither(img::GenericImage, arg::$T; kwargs...)
         return dither(img, DEFAULT_METHOD, arg; kwargs...)
     end
+end
+
+# Dithering to Unicode Braille characters
+function braille(img::GenericImage; kwargs...)
+    return braille(img, DEFAULT_METHOD; kwargs...)
 end

--- a/src/braille.jl
+++ b/src/braille.jl
@@ -5,8 +5,10 @@
 
 Binary dither with algorithm `alg`, then print image in braille.
 """
-function braille(img::GenericImage, alg::AbstractDither, args...; kwargs...)
-    return brailleprint(dither(Gray{Bool}, Gray.(img), alg, args...; kwargs...))
+function braille(img::GenericImage, alg::AbstractDither; invert=false, kwargs...)
+    d = dither(Bool, Gray.(img), alg; kwargs...)
+    invert && return brailleprint(.!d)
+    return brailleprint(d)
 end
 
 """

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -127,3 +127,9 @@ d4def = @inferred dither!(img2def)
 img_zero_based = OffsetMatrix(rand(Float32, 10, 10), 0:9, 0:9)
 @test_throws ArgumentError dither(img_zero_based, FloydSteinberg())
 @test_throws ArgumentError dither(img_zero_based)
+
+## Braille dithering
+braille(img, Bayer())
+braille(img)
+braille(img, Bayer(); invert=true)
+braille(img; invert=true)


### PR DESCRIPTION
Towards #83: 
* default method is `FloydSteinberg` (same as `dither`)
* output can be inverted via the kwarg `invert`, e.g. `braille(img; invert=true)`

